### PR TITLE
Update documentation links for github instructions for organization

### DIFF
--- a/book/guide/how-to-use/how-to-use-overview.md
+++ b/book/guide/how-to-use/how-to-use-overview.md
@@ -11,9 +11,9 @@ Group leaders and members edit the book together to create a living document whi
 * Nominate a group memeber to
 [fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks)
 this repo.
-** If your group doesn't have a GitHub organisation, we suggest that
+	* If your group doesn't have a GitHub organisation, we suggest that
 you [create](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/creating-a-new-organization-from-scratch) one, and then fork this repo. to the organisation account.
-* All other group members fork the orangisation repo. 
+* All other group members can then fork the orangisation repo. 
 
 ## 2. Edit the book with your team
 
@@ -38,7 +38,7 @@ you [create](https://docs.github.com/en/organizations/collaborating-with-groups-
 ## 3. Make your handbook available online
 
 <!-- TODO: add link below-->
-* Follow the instructions [here](https://github.com/very-good-science/our-handbook/blob/main/book/guide/how-to-use/put-online.md) to make your handbook available online.
+* Follow the instructions [here](put-online) to make your handbook available online.
 * Make sure that you link to the handbook on your group website, and in any job (including PhD studentship) openings.
 * Please tell us if you use this handbook! 
 

--- a/book/guide/how-to-use/how-to-use-overview.md
+++ b/book/guide/how-to-use/how-to-use-overview.md
@@ -8,17 +8,21 @@ Group leaders and members edit the book together to create a living document whi
 
 ## 1. Make your own copy this repo
 
-* Nominate a group memeber to [fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks) the repo. (if your group doesn't have a GitHub organisation, perhaps make one and fork to there).
-* All other group members fork the orangisation repo 
+* Nominate a group memeber to
+[fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks)
+this repo.
+** If your group doesn't have a GitHub organisation, we suggest that
+you [create](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/creating-a-new-organization-from-scratch) one, and then fork this repo. to the organisation account.
+* All other group members fork the orangisation repo. 
 
 ## 2. Edit the book with your team
 
 ### Via web:
 
-* Navigate to your forked repository, in `<book name>/book/template`choose the section of the book you'd like to edit (e.g. adding team-members).
+* Navigate to your forked repository, in `<book name>/book/template` choose the section of the book you'd like to edit (e.g. adding team-members).
 * Click `Edit this file` 🖊 in the top-right submenu and make your changes.
 * All changes can be previewed by switching to the `Preview` window.
-* Scrawl to the bottom of the page and under `Commit changes` type in a commit message (e.g. "adding team member to `index.md`").
+* Scroll to the bottom of the page and under `Commit changes` type in a commit message (e.g. "adding team member to `index.md`").
 * Check "Create a new branch for this commit and start a pull request" box, giving your branch an appopiate name (e.g. <my-inital>-team-update).
 * Click `Propose changes`.
 * To add your changes to the group book, navigate to the homepage of your repository and click "compare & pull request".

--- a/book/guide/how-to-use/how-to-use-overview.md
+++ b/book/guide/how-to-use/how-to-use-overview.md
@@ -23,7 +23,7 @@ you [create](https://docs.github.com/en/organizations/collaborating-with-groups-
 * Click `Edit this file` 🖊 in the top-right submenu and make your changes.
 * All changes can be previewed by switching to the `Preview` window.
 * Scroll to the bottom of the page and under `Commit changes` type in a commit message (e.g. "adding team member to `index.md`").
-* Check "Create a new branch for this commit and start a pull request" box, giving your branch an appopiate name (e.g. <my-inital>-team-update).
+* Check "push to main branch" box.
 * Click `Propose changes`.
 * To add your changes to the group book, navigate to the homepage of your repository and click "compare & pull request".
 * Write a quick description on your changes and click "Create pull request".

--- a/book/guide/how-to-use/put-online.md
+++ b/book/guide/how-to-use/put-online.md
@@ -2,8 +2,8 @@
 
 To make your handbook visible online, follow these instructions.
 
-## 1. Create Merge request
-   * See [here](how-to-use) for insructions on editting the merge requests.
+## 1. Create Pull request
+   * See [here](how-to-use) for insructions on editting the pull requests.
 
 ## 2. GitHub Actions
    * GitHub actions makes it easy to automate all your software workflows with CI/CD builds.
@@ -12,7 +12,7 @@ To make your handbook visible online, follow these instructions.
    * Both `build-site` and `deploy-book` are triggered automatically upon a Merge Request, here you can monitor when they finish.
 
 ## 3. GitHub pages
-   * From the top-menu navigate to `Setting`
+   * From the top-menu navigate to `Settings`
    * From the left side menu click on `Pages`
    * You will see the URL of your handbook in the highlighted box ("Your site is ready to be published at <>")
    * **make sure** the `Source` is set to the `gh-pages` branch and click `Save`

--- a/book/guide/how-to-use/put-online.md
+++ b/book/guide/how-to-use/put-online.md
@@ -15,4 +15,4 @@ To make your handbook visible online, follow these instructions.
    * From the top-menu navigate to `Settings`
    * From the left side menu click on `Pages`
    * You will see the URL of your handbook in the highlighted box ("Your site is ready to be published at <>")
-   * **make sure** the `Source` is set to the `gh-pages` branch and click `Save`
+   * **Make sure** the `Source` is set to the `gh-pages` branch and click `Save`


### PR DESCRIPTION
## Description
I've added a link to instructions on how to create an organisation github, and fixed some typos.

- [ ] Marked as draft
- [ ] Linked to issue
- [ ] Filled in description
- [ ] Gave this Pull Request a descriptive title
 
## Checklist (maintainer)
<!-- Maintainers: please check the following before you merge-->
- [ ] Built site locally.
- [ ] Changes are as discussed in issue.
- [ ] The PR is to the Our Handbook `main` branch
- [ ] New pages are linked in the TOC/navigation?
- [ ] Have we added the contributor to our all-contributors?
- [ ] One sentence per line
